### PR TITLE
Mark more connect() options as optional

### DIFF
--- a/lib/imap-flow.js
+++ b/lib/imap-flow.js
@@ -105,11 +105,11 @@ class ImapFlow extends EventEmitter {
      * @param {Boolean} [options.disableCompression=false] if `true` then client does not try to use COMPRESS=DEFLATE extension
      * @param {Object} options.auth Authentication options. Authentication is requested automatically during <code>connect()</code>
      * @param {String} options.auth.user Usename
-     * @param {String} options.auth.pass Password, if using regular authentication
-     * @param {String} options.auth.accessToken OAuth2 Access Token, if using OAuth2 authentication
+     * @param {String} [options.auth.pass] Password, if using regular authentication
+     * @param {String} [options.auth.accessToken] OAuth2 Access Token, if using OAuth2 authentication
      * @param {IdInfoObject} [options.clientInfo] Client identification info
      * @param {Boolean} [options.disableAutoIdle=false] if `true` then IDLE is not started automatically. Useful if you only need to perform specific tasks over the connection
-     * @param {Object} options.tls Additional TLS options (see [Node.js TLS connect](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback) for all available options)
+     * @param {Object} [options.tls] Additional TLS options (see [Node.js TLS connect](https://nodejs.org/api/tls.html#tls_tls_connect_options_callback) for all available options)
      * @param {Boolean} [options.tls.rejectUnauthorized=true] if `false` then client accepts self-signed and expired certificates from the server
      * @param {String} [options.tls.minVersion=TLSv1.2] latest Node.js defaults to *'TLSv1.2'*, for older mail servers you might need to use something else, eg *'TLSv1'*
      * @param {Number} [options.tls.minDHSize=1024] Minimum size of the DH parameter in bits to accept a TLS connection


### PR DESCRIPTION
These options are incorrectly marked as required when using TypeScript.