### PR TITLE
fix search-compiler.js variable errors

### DIFF
--- a/lib/search-compiler.js
+++ b/lib/search-compiler.js
@@ -34,7 +34,7 @@ let processDateField = (attributes, term, value) => {
         return;
     }
 
-    setOpt(attributes, term, value);
+    setOpt(attributes, term, date);
 };
 
 module.exports.searchCompiler = (connection, query) => {
@@ -117,7 +117,7 @@ module.exports.searchCompiler = (connection, query) => {
                 case 'SENTBEFORE':
                 case 'SENTON':
                 case 'SENTSINCE':
-                    processDateField(term, params[term]);
+                    processDateField(attributes, term, params[term]);
                     break;
 
                 case 'KEYWORD':


### PR DESCRIPTION
```js
client.fetch({'before': new Date()});
```
```
TypeError: Cannot read property 'toString' of undefined
    at formatDate (node_modules/imapflow/lib/tools.js:581:77)
    at processDateField (node_modules/imapflow/lib/search-compiler.js:32:16)
    at Object.keys.forEach.term (node_modules/imapflow/lib/search-compiler.js:120:21)
    at Array.forEach (<anonymous>)
    at walk (node_modules/imapflow/lib/search-compiler.js:46:35)
    at module.exports.searchCompiler (node_modules/imapflow/lib/search-compiler.js:217:5)
    at module.exports (node_modules/imapflow/lib/commands/search.js:22:22)
    at ImapFlow.run (node_modules/imapflow/lib/imap-flow.js:2146:28)
    at ImapFlow.resolveRange (node_modules/imapflow/lib/imap-flow.js:920:36)
    at ImapFlow.fetch (node_modules/imapflow/lib/imap-flow.js:1776:32)
```